### PR TITLE
Magento 2.0.0-RC support

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -4,12 +4,13 @@ namespace EW\ConfigScopeHints\Helper;
 use \Magento\Store\Model\Website;
 use \Magento\Store\Model\Store;
 
-class Data extends  \Magento\Framework\App\Helper\AbstractHelper
+class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
     /** @var \Magento\Framework\App\Helper\Context */
-    protected $_context;
+    protected $context;
+
     /** @var \Magento\Store\Model\StoreManagerInterface */
-    protected $_storeManger;
+    protected $storeManager;
 
     /**
      * @param \Magento\Framework\App\Helper\Context $context
@@ -17,10 +18,10 @@ class Data extends  \Magento\Framework\App\Helper\AbstractHelper
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
     ) {
-        $this->_storeManger = $storeManager;
-        $this->_context = $context;
+        $this->storeManager = $storeManager;
+        $this->context = $context;
     }
 
     /**
@@ -32,7 +33,7 @@ class Data extends  \Magento\Framework\App\Helper\AbstractHelper
     public function getScopeTree() {
         $tree = array('websites' => array());
 
-        $websites = $this->_storeManger->getWebsites();
+        $websites = $this->storeManager->getWebsites();
 
         /* @var $website Website */
         foreach($websites as $website) {
@@ -56,7 +57,7 @@ class Data extends  \Magento\Framework\App\Helper\AbstractHelper
      * @return mixed
      */
     protected function _getConfigValue($path, $contextScope, $contextScopeId) {
-        return $this->_context->getScopeConfig()->getValue($path, $contextScope, $contextScopeId);
+        return $this->context->getScopeConfig()->getValue($path, $contextScope, $contextScopeId);
     }
 
     /**
@@ -69,7 +70,7 @@ class Data extends  \Magento\Framework\App\Helper\AbstractHelper
      * @param $contextScopeId
      * @return array
      */
-    public function getOverridenLevels($path, $contextScope, $contextScopeId) {
+    public function getOverriddenLevels($path, $contextScope, $contextScopeId) {
         $tree = $this->getScopeTree();
 
         $currentValue = $this->_getConfigValue($path, $contextScope, $contextScopeId);
@@ -151,12 +152,12 @@ class Data extends  \Magento\Framework\App\Helper\AbstractHelper
                     $scopeLabel = sprintf(
                         'website <a href="%s">%s</a>',
                         $url,
-                        $this->_storeManger->getWebsite($scopeId)->getName()
+                        $this->storeManager->getWebsite($scopeId)->getName()
                     );
 
                     break;
                 case 'store':
-                    $store = $this->_storeManger->getStore($scopeId);
+                    $store = $this->storeManager->getStore($scopeId);
                     $website = $store->getWebsite();
                     $url = $this->_context->getUrlBuilder()->getUrl(
                         '*/*/*',

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -13,15 +13,28 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected $storeManager;
 
     /**
+     * Url Builder
+     *
+     * @var \Magento\Backend\Model\Url
+     */
+    protected $urlBuilder;
+
+    /**
      * @param \Magento\Framework\App\Helper\Context $context
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Backend\Model\Url $urlBuilder
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Backend\Model\Url $urlBuilder
     ) {
         $this->storeManager = $storeManager;
         $this->context = $context;
+        // Ideally we would just retrieve the urlBuilder using $this->content->getUrlBuilder(), but since it retrieves
+        // an instance of \Magento\Framework\Url instead of \Magento\Backend\Model\Url, we must explicitly request it
+        // via DI.
+        $this->urlBuilder = $urlBuilder;
     }
 
     /**
@@ -142,11 +155,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $section = $form->getSectionCode();
             switch($scope) {
                 case 'website':
-                    $url = $this->_context->getUrlBuilder()->getUrl(
+                    $url = $this->urlBuilder->getUrl(
                         '*/*/*',
                         array(
-                            'section'=>$section,
-                            'website'=>$scopeId
+                            'section' => $section,
+                            'website' => $scopeId
                         )
                     );
                     $scopeLabel = sprintf(
@@ -159,12 +172,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 case 'store':
                     $store = $this->storeManager->getStore($scopeId);
                     $website = $store->getWebsite();
-                    $url = $this->_context->getUrlBuilder()->getUrl(
+                    $url = $this->urlBuilder->getUrl(
                         '*/*/*',
                         array(
                             'section'   => $section,
-                            'website'   => $website->getCode(),
-                            'store'     => $store->getCode()
+                            'store'     => $store->getId()
                         )
                     );
                     $scopeLabel = sprintf(

--- a/Model/Plugin.php
+++ b/Model/Plugin.php
@@ -7,13 +7,13 @@ use \Magento\Framework\Phrase;
 class Plugin
 {
     /** @var \EW\ConfigScopeHints\Helper\Data */
-    protected $_helper;
+    protected $helper;
 
     /**
      * @param \EW\ConfigScopeHints\Helper\Data $helper
      */
     public function __construct(\EW\ConfigScopeHints\Helper\Data $helper) {
-        $this->_helper = $helper;
+        $this->helper = $helper;
     }
 
     /**
@@ -37,13 +37,13 @@ class Plugin
                 $currentScopeId = $form->getStoreCode();
                 break;
         }
-        $overriddenLevels = $this->_helper->getOverridenLevels($field->getPath(), $form->getScope(), $currentScopeId);
+        $overriddenLevels = $this->helper->getOverriddenLevels($field->getPath(), $form->getScope(), $currentScopeId);
 
         /* @var $returnPhrase Phrase */
         $labelPhrase = $getScopeLabel($field);
 
         if(!empty($overriddenLevels)) {
-            $scopeHintText = $labelPhrase . $this->_helper->formatOverriddenScopes($form, $overriddenLevels);
+            $scopeHintText = $labelPhrase . $this->helper->formatOverriddenScopes($form, $overriddenLevels);
 
             // create new phrase, now that constituent strings are translated individually
             $labelPhrase = new Phrase($scopeHintText, $labelPhrase->getArguments());

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each of these commands should be run from the command line at the Magento 2 root
 First, add this repository to your `composer.json` by running the following.
 ```
 # add this repository to your composer.json
-$ composer config repositories.magento2-configscopehints vcs https://github.com/ericthehacker/magento2-configscopehints.git
+$ composer config repositories.magento2-configscopehints git https://github.com/ericthehacker/magento2-configscopehints.git
 
 # require module
 $ composer require ericthehacker/magento2-configscopehints
@@ -56,4 +56,4 @@ Clicking on the notification bulb displays a detailed list of the exact scope(s)
 
 ## Compatibility and Technical Notes
 
-This module was written and tested against version [0.74.0-beta4](https://github.com/magento/magento2/releases/tag/0.74.0-beta4). The hints are accomplished using intercepters, so there should be no compatibility concerns ([unlike Magento 1](https://github.com/ericthehacker/magento-configscopehints#rewrites)). This version is post-RC2, so the intercepters API should stable at this point.
+This module was written and tested against version [2.0.0-rc](https://github.com/magento/magento2/releases/tag/2.0.0-rc). The hints are accomplished using intercepters, so there should be no compatibility concerns ([unlike Magento 1](https://github.com/ericthehacker/magento-configscopehints#rewrites)). This version is post-RC, so the intercepters API should stable at this point.

--- a/composer.json
+++ b/composer.json
@@ -2,22 +2,25 @@
     "name": "ericthehacker/magento2-configscopehints",
     "description": "Magento 2 store config override hints module",
     "require": {
-        "magento/magento-composer-installer": "*"
+        "magento/framework": "*"
     },
     "type": "magento2-module",
-    "version": "2.0",
-    "extra": {
-        "map": [
-            [
-                "*",
-                "EW/ConfigScopeHints"
-            ]
-        ]
+    "version": "2.1",
+    "autoload": {
+        "files": [ "registration.php" ],
+        "psr-4": {
+            "EW\\ConfigScopeHints\\": ""
+        }
     },
     "authors": [
         {
             "name": "Eric Wiese",
             "homepage": "https://ericwie.se/",
+            "role": "Developer"
+        },
+        {
+            "name": "Erik Hansen",
+            "homepage": "https://www.classyllama.com/",
             "role": "Developer"
         }
     ]

--- a/registration.php
+++ b/registration.php
@@ -1,0 +1,7 @@
+<?php
+
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'EW_ConfigScopeHints',
+    __DIR__
+);


### PR DESCRIPTION
This PR implements support for Magento 2.0.0-RC. Summary of changes:
- Added registration.php
- Updated composer.json to new approach for registering modules. **Changed composer.json version to 2.1, so please tag a 2.1 release**.
- Fixed misspellings
- Fixed issue where urls for configuration scopes were not working
