### PR TITLE
Fix issue with simplistic source models that return value-label-pairs instead of the expected array structure

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -113,15 +113,25 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $labels = []; //reset labels so we can add human-friendly labels
 
             $optionsByValue = [];
-            foreach($field->getOptions() as $option) {
-                $optionsByValue[$option['value']] = $option;
+            foreach($field->getOptions() as $optionValue => $option) {
+                switch (true) {
+                    case is_array($option):
+                        $optionValue = isset($option['value']) ? $option['value'] : $optionValue;
+                        $optionLabel = isset($option['label']) ? $option['label'] : '';
+                        break;
+                    case $option instanceof \Magento\Framework\Phrase:
+                        $optionLabel = $option;
+                        break;
+                }
+
+                $optionsByValue[$optionValue] = $optionLabel;
             }
 
             $values = explode(',', $value);
 
             foreach($values as $valueInstance) {
                 $labels[] = isset($optionsByValue[$valueInstance])
-                    ? $optionsByValue[$valueInstance]['label'] : $valueInstance;
+                    ? $optionsByValue[$valueInstance] : $valueInstance;
 
             }
         }


### PR DESCRIPTION
Some Magento 2 modules (e.g. `Magento_CatalogPermissions`) use source models that do not return the expected array structure containing a `'label'` and `'value'` key, but instead return a simplified array where the options value is used as key and the options label is used as value.

*Expected structure*
```php
[
    ['value' => 0, 'label' => 'No'],
    ['value' => 1, 'label' => 'Yes'],
    ['value' => 2, 'label' => 'Maybe'],
]
```

*Simplified:*
```php
[
    0 => 'No',
    1 => 'Yes',
    2 => 'Maybe',
]
```

This pull request fixes this issue.